### PR TITLE
Updates SSL Certificate

### DIFF
--- a/terraform/serverless/web_tier/main.tf
+++ b/terraform/serverless/web_tier/main.tf
@@ -63,11 +63,11 @@ resource "aws_s3_bucket_policy" "dev_static_files" {
     Id      = "PublicReadAccess"
     Statement = [
       {
-        Sid    = "PublicReadGetObject"
-        Effect = "Allow"
+        Sid       = "PublicReadGetObject"
+        Effect    = "Allow"
         Principal = "*"
-        Action   = "s3:GetObject"
-        Resource = "${aws_s3_bucket.static_files["dev"].arn}/*"
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.static_files["dev"].arn}/*"
       }
     ]
   })

--- a/terraform/serverless/web_tier/variables.tf
+++ b/terraform/serverless/web_tier/variables.tf
@@ -41,7 +41,7 @@ variable "domain_aliases" {
 
 variable "certificate_arn" {
   description = "ARN of the ACM certificate for CloudFront"
-  default     = "arn:aws:acm:us-east-1:637423562225:certificate/03361d5b-5364-4894-b08c-7d616666f112"
+  default     = "arn:aws:acm:us-east-1:637423562225:certificate/2245c5fa-a3d3-485c-aa9d-953e277d8700"
 }
 
 variable "cache_policy_id" {

--- a/terraform/ssl_cert/main.tf
+++ b/terraform/ssl_cert/main.tf
@@ -1,5 +1,5 @@
 /*
-This file configures the necessary SSL certificate to use with 
+This file configures the necessary SSL certificate to use with
 the load balancer and CloudFront distribution.
 */
 
@@ -17,10 +17,33 @@ resource "aws_acm_certificate" "ssl" {
   tags = {
     Name    = "SSL Certificate"
     Project = "Lyria"
-    Use     = "Load balancer and CloudFront distribution"
+    Use     = "Static Files CloudFront distribution"
   }
 }
 
+resource "aws_route53_record" "validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.ssl.domain_validation_options :
+    dvo.domain_name => {
+      name  = dvo.resource_record_name
+      type  = dvo.resource_record_type
+      value = dvo.resource_record_value
+    }
+  }
+
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.value]
+  ttl     = 300
+}
+
 resource "aws_acm_certificate_validation" "ssl" {
-  certificate_arn = aws_acm_certificate.ssl.arn
+  certificate_arn         = aws_acm_certificate.ssl.arn
+  validation_record_fqdns = [for record in aws_route53_record.validation : record.fqdn]
+
+}
+
+data "aws_route53_zone" "main" {
+  name = var.domain_name
 }


### PR DESCRIPTION
The old certificate had old domains in addition to the correct ones that are still in use. The new certificate is now under control of terraform and only issued for the correct domains.